### PR TITLE
fix: issue #8 - unexpected # in generated config

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ if [ "${SIGNER}x" != "x" ]; then
   echo "::endgroup"
 fi
 
-SIGNING_CONFIG=$(fgrep -B1 "Type: AWS::Serverless::Function" $TEMPLATE | grep -e ':$' | sed "s/^ *\(.*\):/\1=$PROFILE /" | grep -ve '^#' | tr -d '\n')
+SIGNING_CONFIG=$(fgrep -B1 "Type: AWS::Serverless::Function" $TEMPLATE | grep -e ':$' | sed "s/^ *\(.*\):/\1=$PROFILE /" | grep -ve '^#' | tr -d '\n' | xargs)
 SUCCESS=$?
 
 OUTPUT="--signing-profiles $SIGNING_CONFIG"


### PR DESCRIPTION
#### Description

A small change has been to the entrypoint.sh ensuring that no trailing space exists in the signing_config output. 

#### Motivation and Context

In some configurations an unexpected # was appended to the second signing configuration profile but not to any others and was causing the second function not to be signed and consequently failing the deployment. Investigation found that ensuring no trailing space ever existed at the end of the string fixed this issue.

Closes #8

#### How Has This Been Tested?

This has been tested as a local action in one of the repositories that was signing four functions and noticed this on the second. The change has subsequently been applied to the entrypoint.sh and undergone testing on the branch.

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

No changes to the documentation or tests applicable
