### PR TITLE
fix: update deprecated commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       
       - name: bump the version
         id: bumper
-        uses: tomerfi/version-bumper-action@1.1.3
+        uses: tomerfi/version-bumper-action@1.2.1
 
       - name: Update README major version
         id: version_count
-        run: echo "::set-output name=count::$(fgrep -c sam-code-signing-config@v${{ steps.bumper.outputs.major_part }} ) README.md"
+        run: echo "count=$(fgrep -c sam-code-signing-config@v${{ steps.bumper.outputs.major_part }} ) README.md" >> $GITHUB_OUTPUT
 
       - name: Update README usage example
         if: steps.version_count.outputs.count == 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,18 +22,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Test entry point or fail
         run: |
           EXPECTED="SIGNING_CONFIG: --signing-profiles HelloWorldFunction=TestProfile HelloAgainFunction=TestProfile"
           OUT=$(bash ./entrypoint.sh ./test/template.yml TestProfile | grep SIGNING_CONFIG | xargs)
           echo "::debug::EXPECTED: $EXPECTED"
-          echo ":debug::   ACTUAL: $OUT"
+          echo "::debug::   ACTUAL: $OUT"
           [ "$OUT" = "$EXPECTED" ] || exit 1
 
       - name: Lint the dockerfile
-        uses: hadolint/hadolint-action@v2.0.0
+        uses: hadolint/hadolint-action@v2.1.0
 
       - name: Test the action
         id: test


### PR DESCRIPTION
#### Description

Updated to reduce amount of changes required to fix all the GitGub deprecations


#### Motivation and Context

GitHub is deprecating some commands and moving to Node.js 16


Closes #

#### How Has This Been Tested?

Locally

#### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
