### PR TITLE
fix: github deprecations changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     uses: rusty-actions/sam-code-signing-config/.github/workflows/test.yml@main
+
   action:
     name: Build and release action
     needs: test
@@ -25,7 +26,7 @@ jobs:
 
       - name: Update README major version
         id: version_count
-        run: echo "count=$(fgrep -c sam-code-signing-config@v${{ steps.bumper.outputs.major_part }} ) README.md" >> $GITHUB_OUTPUT
+        run: echo "count=$(fgrep -c sam-code-signing-config@v${{ steps.bumper.outputs.major_part }} README.md)" >> $GITHUB_OUTPUT
 
       - name: Update README usage example
         if: steps.version_count.outputs.count == 0
@@ -52,12 +53,9 @@ jobs:
         with:
           tag: ${{ steps.bumper.outputs.new_version }}
 
-      - name: Create Release
-        id: create_release
-        uses: nickatnight/releases-action@v3
-        #        if: startsWith(github.ref, 'refs/tags/')
+      - name: Create a Release
+        uses: elgohr/Github-Release-Action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          branch: main
-          tag: ${{ steps.bumper.outputs.new_version }}
+          title: ${{ steps.bumper.outputs.new_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           [ "$OUT" = "$EXPECTED" ] || exit 1
 
       - name: Lint the dockerfile
-        uses: hadolint/hadolint-action@v2.1.0
+        uses: hadolint/hadolint-action@v3.0.0
 
       - name: Test the action
         id: test

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,8 @@ echo "::group::signing output"
 echo "SIGNING_CONFIG: $OUTPUT"
 echo "::endgroup"
 
-echo "::set-output name=signing_config::$OUTPUT"
+echo "signing_config<<EOF" >> $GITHUB_OUTPUT
+echo "${OUTPUT}" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
 
 exit $SUCCESS


### PR DESCRIPTION
#### Description

These updates implement the changes required to allow the action to continue working beyond the removal of the GitHub deprecation changes of set-output.

#### Motivation and Context

If these changes are not implemented then the action will fail after GitHub remove support for the older syntax. 

Closes #

#### How Has This Been Tested?

locally and in a clone of the repository

#### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
